### PR TITLE
Removing non performance enhancing useCallbacks

### DIFF
--- a/src/components/Overview/Panels/MonthlyBills.tsx
+++ b/src/components/Overview/Panels/MonthlyBills.tsx
@@ -1,5 +1,5 @@
 import { Divider } from '@mui/material';
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { Account, Bill } from '~/types';
 import { useAccountContext } from '~/state';
 import { formatAmount, isNegative } from '~/utils';
@@ -17,10 +17,6 @@ export const MonthlyBills = () => {
     setSelectedBill(bill);
     setIsOpen(true);
   };
-
-  const closePopup = useCallback(() => {
-    setIsOpen(false);
-  }, []);
 
   return (
     <Fragment>
@@ -48,7 +44,11 @@ export const MonthlyBills = () => {
           </h3>
         </div>
       </div>
-      <EditMonthlyBillsPopup isOpen={isOpen} close={closePopup} selectedBill={selectedBill} />
+      <EditMonthlyBillsPopup
+        isOpen={isOpen}
+        close={() => setIsOpen(false)}
+        selectedBill={selectedBill}
+      />
     </Fragment>
   );
 };

--- a/src/components/Overview/Panels/PaymentsDue.tsx
+++ b/src/components/Overview/Panels/PaymentsDue.tsx
@@ -1,5 +1,5 @@
 import { Divider } from '@mui/material';
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { TYPES } from '~/constants';
 import { Account, Bill, Modal, OneOffPayment } from '~/types';
 import { useAccountContext } from '~/state';
@@ -22,9 +22,9 @@ export const PaymentsDue = () => {
       : setIsOpen({ ...isOpen, PAYMENT_DUE: true });
   };
 
-  const closePopup = useCallback(() => {
+  const closePopup = () => {
     setIsOpen({ PAYMENT_DUE: false, BILL: false });
-  }, []);
+  };
 
   return (
     <Fragment>

--- a/src/components/Overview/Totals/BankBalanceCard.tsx
+++ b/src/components/Overview/Totals/BankBalanceCard.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { editAccountCache, EDIT_ACCOUNT_MUTATION } from '~/graphql';
 import { Account } from '~/types';
 import { useAccountContext } from '~/state/account-context';
@@ -22,10 +22,6 @@ export const BankBalanceCard = () => {
   const handleClickOpen = () => {
     setIsOpen(true);
   };
-
-  const closePopup = useCallback(() => {
-    setIsOpen(false);
-  }, []);
 
   const changeBankBalance = (value: number | undefined) => {
     if (value && value !== bankBalance) {
@@ -61,7 +57,7 @@ export const BankBalanceCard = () => {
       {isOpen && (
         <BankBalancePopup
           isOpen={isOpen}
-          close={closePopup}
+          close={() => setIsOpen(false)}
           changeBankBalance={changeBankBalance}
         />
       )}

--- a/src/components/Overview/Totals/MonthlyBillsCard.tsx
+++ b/src/components/Overview/Totals/MonthlyBillsCard.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import ReceiptIcon from '@mui/icons-material/Receipt';
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { addBillCache, CREATE_BILL_MUTATION } from '~/graphql';
 import { Account, Bill } from '~/types';
 import { useAccountContext } from '~/state/account-context';
@@ -38,10 +38,6 @@ export const MonthlyBillsCard = () => {
     setIsOpen(true);
   };
 
-  const closePopup = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
   return (
     <Fragment>
       {!loading ? (
@@ -58,7 +54,7 @@ export const MonthlyBillsCard = () => {
       <MonthlyBillsPopup
         title="Add Monthly Bill"
         isOpen={isOpen}
-        close={closePopup}
+        close={() => setIsOpen(false)}
         onSave={createNewBill}
       />
     </Fragment>

--- a/src/components/Overview/Totals/MonthlyIncomeCard.tsx
+++ b/src/components/Overview/Totals/MonthlyIncomeCard.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import LocalAtmIcon from '@mui/icons-material/LocalAtm';
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { editAccountCache, EDIT_ACCOUNT_MUTATION } from '~/graphql';
 import { Account } from '~/types';
 import { useAccountContext } from '~/state/account-context';
@@ -22,10 +22,6 @@ export const MonthlyIncomeCard = () => {
   const handleClickOpen = () => {
     setIsOpen(true);
   };
-
-  const closePopup = useCallback(() => {
-    setIsOpen(false);
-  }, []);
 
   const changeMonthlyIncome = (value: number | undefined) => {
     if (value && value !== monthlyIncome) {
@@ -61,7 +57,7 @@ export const MonthlyIncomeCard = () => {
       {isOpen && (
         <MonthlyIncomePopup
           isOpen={isOpen}
-          close={closePopup}
+          close={() => setIsOpen(false)}
           changeMonthlyIncome={changeMonthlyIncome}
         />
       )}

--- a/src/components/Overview/Totals/PaymentsDueCard.tsx
+++ b/src/components/Overview/Totals/PaymentsDueCard.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { addPaymentCache, CREATE_ONE_OFF_PAYMENT_MUTATION } from '~/graphql';
 import { Account, OneOffPayment } from '~/types';
 import { useAccountContext } from '~/state/account-context';
@@ -39,10 +39,6 @@ export const PaymentsDueCard = () => {
     setIsOpen(true);
   };
 
-  const closePopup = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
   return (
     <Fragment>
       {!loading ? (
@@ -59,7 +55,7 @@ export const PaymentsDueCard = () => {
       <PaymentsDuePopup
         title="Add Upcoming Payment"
         isOpen={isOpen}
-        close={closePopup}
+        close={() => setIsOpen(false)}
         onSave={createNewOneOffPayment}
       />
     </Fragment>


### PR DESCRIPTION
Following the rules set out as here: https://react.dev/reference/react/useCallback

> Caching a function with useCallback  is only valuable in a few cases:
> 
> You pass it as a prop to a component wrapped in [memo.](https://react.dev/reference/react/memo) You want to skip re-rendering if the value hasn’t changed. Memoization lets your component re-render only if dependencies changed.
>
> The function you’re passing is later used as a dependency of some Hook.
>  For example, another function wrapped in useCallback depends on it, or you depend on this function from [useEffect.](https://react.dev/reference/react/useEffect)
> 
> There is no benefit to wrapping a function in useCallback in other cases.