### PR TITLE
feat: separate pay/delete functionality for one off payments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
+import CloseIcon from '@mui/icons-material/Close';
 import { ApolloProvider } from '@apollo/client/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { closeSnackbar, SnackbarProvider } from 'notistack';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { AccountProvider } from './state/account-context';
-import { Button } from '@mui/material';
+import { IconButton } from '@mui/material';
 import { client } from './graphql';
 import { AppRoutes } from './routes';
 import { theme } from './utils';
@@ -18,11 +19,9 @@ const App = () => {
             anchorOrigin={{ horizontal: 'center', vertical: 'top' }}
             autoHideDuration={2500}
             action={key => (
-              <Button
-                onClick={() => closeSnackbar(key)}
-                style={{ color: '#fff', fontSize: '20px' }}>
-                ✖
-              </Button>
+              <IconButton onClick={() => closeSnackbar(key)}>
+                <CloseIcon fontSize="small" />
+              </IconButton>
             )}>
             <div className="app">
               <Router>

--- a/src/components/Overview/Popups/EditPopups/EditMonthlyBillsPopup.tsx
+++ b/src/components/Overview/Popups/EditPopups/EditMonthlyBillsPopup.tsx
@@ -51,7 +51,7 @@ export const EditMonthlyBillsPopup = ({
       editBill: { bill, success }
     } = response;
 
-    enqueueSnackbar(`${bill.name} updated`, { variant: 'success' });
+    enqueueSnackbar(`${bill.name} bill updated`, { variant: 'success' });
 
     if (success && !selectedBill?.paid && bill?.paid) {
       const newBalance = bankBalance - bill?.amount;

--- a/src/components/Overview/Popups/FormPopups/MonthlyBillsPopup.tsx
+++ b/src/components/Overview/Popups/FormPopups/MonthlyBillsPopup.tsx
@@ -1,4 +1,8 @@
 import DeleteIcon from '@mui/icons-material/Delete';
+import { ChangeEvent, DispatchWithoutAction, KeyboardEvent, useState } from 'react';
+import { useAccountContext } from '~/state/account-context';
+import { Bill } from '~/types';
+import { Tooltip } from '@mui/material';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import Dialog from '@mui/material/Dialog';
@@ -9,9 +13,6 @@ import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
-import { ChangeEvent, DispatchWithoutAction, KeyboardEvent, useState } from 'react';
-import { useAccountContext } from '~/state/account-context';
-import { Bill } from '~/types';
 
 interface MonthlyBillsPopupProps {
   title: string;
@@ -82,14 +83,16 @@ export const MonthlyBillsPopup = ({
       onClose={handleClose}
       aria-labelledby="form-dialog-title"
       className="monthly-bills-popup"
-      maxWidth={'xs'}
+      maxWidth="xs"
       fullWidth>
       <DialogTitle id="form-dialog-title">
         {title}
         {onDelete && (
-          <IconButton onClick={handleDeleteClicked} disabled={!name || (!amount && amount !== 0)}>
-            <DeleteIcon />
-          </IconButton>
+          <Tooltip title="Delete">
+            <IconButton onClick={handleDeleteClicked} disabled={!name || (!amount && amount !== 0)}>
+              <DeleteIcon />
+            </IconButton>
+          </Tooltip>
         )}
       </DialogTitle>
       <DialogContent>

--- a/src/components/Overview/Popups/FormPopups/PaymentsDuePopup.tsx
+++ b/src/components/Overview/Popups/FormPopups/PaymentsDuePopup.tsx
@@ -1,4 +1,9 @@
 import DeleteIcon from '@mui/icons-material/Delete';
+import PaidIcon from '@mui/icons-material/Paid';
+import { Box, Tooltip } from '@mui/material';
+import { ChangeEvent, DispatchWithoutAction, Fragment, KeyboardEvent, useState } from 'react';
+import { useAccountContext } from '~/state/account-context';
+import { OneOffPayment } from '~/types';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -8,9 +13,6 @@ import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
-import { ChangeEvent, DispatchWithoutAction, KeyboardEvent, useState } from 'react';
-import { useAccountContext } from '~/state/account-context';
-import { OneOffPayment } from '~/types';
 
 interface PaymentsDuePopupProps {
   title: string;
@@ -19,7 +21,7 @@ interface PaymentsDuePopupProps {
   defaultName?: string;
   defaultAmount?: number | string;
   onSave: ({ name, amount, account }: OneOffPayment) => void;
-  onDelete?: DispatchWithoutAction;
+  onDelete?: (paid: boolean) => void;
 }
 
 export const PaymentsDuePopup = ({
@@ -45,8 +47,8 @@ export const PaymentsDuePopup = ({
     handleClose();
   };
 
-  const handleDeleteClicked = () => {
-    onDelete && onDelete();
+  const handleButtonClicked = (paid: boolean) => {
+    onDelete && onDelete(paid);
     close();
   };
 
@@ -77,15 +79,30 @@ export const PaymentsDuePopup = ({
       onClose={handleClose}
       aria-labelledby="form-dialog-title"
       className="payments-due-popup"
-      maxWidth={'xs'}
+      maxWidth="xs"
       fullWidth>
       <DialogTitle id="form-dialog-title">
         {title}
-        {onDelete && (
-          <IconButton onClick={handleDeleteClicked} disabled={!name || (!amount && amount !== 0)}>
-            <DeleteIcon />
-          </IconButton>
-        )}
+        <Box>
+          {onDelete && (
+            <Fragment>
+              <Tooltip title="Pay">
+                <IconButton
+                  onClick={() => handleButtonClicked(true)}
+                  disabled={!name || (!amount && amount !== 0)}>
+                  <PaidIcon />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Delete">
+                <IconButton
+                  onClick={() => handleButtonClicked(false)}
+                  disabled={!name || (!amount && amount !== 0)}>
+                  <DeleteIcon />
+                </IconButton>
+              </Tooltip>
+            </Fragment>
+          )}
+        </Box>
       </DialogTitle>
       <DialogContent>
         <DialogContentText>Name</DialogContentText>

--- a/src/components/Overview/Totals/MonthlyBillsCard.tsx
+++ b/src/components/Overview/Totals/MonthlyBillsCard.tsx
@@ -32,7 +32,7 @@ export const MonthlyBillsCard = () => {
           }
         }
       ) => addBillCache(cache, bill, user),
-      onCompleted: () => enqueueSnackbar(`${bill.name} added`, { variant: 'success' }),
+      onCompleted: () => enqueueSnackbar(`${bill.name} bill added`, { variant: 'success' }),
       onError: handleGQLError
     });
   };

--- a/src/components/Overview/Totals/PaymentsDueCard.tsx
+++ b/src/components/Overview/Totals/PaymentsDueCard.tsx
@@ -32,7 +32,8 @@ export const PaymentsDueCard = () => {
           }
         }
       ) => addPaymentCache(cache, oneOffPayment, user),
-      onCompleted: () => enqueueSnackbar(`${oneOffPayment.name} added`, { variant: 'success' }),
+      onCompleted: () =>
+        enqueueSnackbar(`${oneOffPayment.name} payment added`, { variant: 'success' }),
       onError: handleGQLError
     });
   };

--- a/src/components/StandardPage/StandardPage.tsx
+++ b/src/components/StandardPage/StandardPage.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react/jsx-runtime';
 import { BottomNav } from '../BottomNav';
 import { Header } from '../Header';
 
@@ -8,11 +9,11 @@ interface StandardPageProps {
 }
 
 export const StandardPage = ({ children, header = true, bottomNav = true }: StandardPageProps) => (
-  <>
+  <Fragment>
     <div className="page">
       {header && <Header />}
       <main>{children}</main>
     </div>
     {bottomNav && <BottomNav />}
-  </>
+  </Fragment>
 );

--- a/src/scss/components/_popups.scss
+++ b/src/scss/components/_popups.scss
@@ -23,9 +23,10 @@
   }
 }
 
+.monthly-bills-popup,
 .payments-due-popup {
   // Name field margin
-  .MuiFormControl-root:first-of-type {
+  .MuiFormControl-root:not(:last-child) {
     margin-bottom: 16px;
   }
   // Amount final field remove margin

--- a/src/scss/misc/_overwrites.scss
+++ b/src/scss/misc/_overwrites.scss
@@ -11,3 +11,10 @@ input:-webkit-autofill:active {
 input:-webkit-autofill {
   -webkit-text-fill-color: $white !important;
 }
+
+// Notistack
+#notistack-snackbar {
+  text-transform: uppercase;
+  font-weight: bold;
+  font-family: $font-family;
+}


### PR DESCRIPTION
- Fixed some styling & incorrect jsx
- Added pay button inside payment modal that deletes the payment and then subtracts the payment from the bank total
- Delete button now only deletes the payment

New solution that means https://github.com/Craig-97/Money-Manager/issues/16 can be closed